### PR TITLE
Add epicrisis draft context in patient detail

### DIFF
--- a/pacientes/views.py
+++ b/pacientes/views.py
@@ -99,9 +99,13 @@ def detalle_paciente(request, paciente_id):
             else:
                 messages.error(request, "Error al guardar evolución.")
 
-    # Epicrisis: mostrar formulario solo si no hay borrador
-    hay_borrador_epicrisis = Epicrisis.objects.filter(episodio=episodio_activo, finalizado=False).exists() if episodio_activo else False
-    epicrisis_form = EpicrisisForm() if not hay_borrador_epicrisis else None
+    # Epicrisis: obtener borrador del episodio activo, si existe
+    epicrisis_borrador = None
+    if episodio_activo:
+        epicrisis_borrador = Epicrisis.objects.filter(
+            episodio=episodio_activo, finalizado=False
+        ).first()
+    epicrisis_form = EpicrisisForm() if not epicrisis_borrador else None
 
     context = {
         'paciente': paciente,
@@ -110,7 +114,7 @@ def detalle_paciente(request, paciente_id):
         'form': form,
         'formset': formset,
         'epicrisis_form': epicrisis_form,
-        'mostrar_formulario_epicrisis': not hay_borrador_epicrisis,
+        'epicrisis_borrador': epicrisis_borrador,
     }
     return render(request, 'pacientes/detalle_paciente.html', context)
 


### PR DESCRIPTION
## Summary
- fetch unfinalized epicrisis draft in `detalle_paciente`
- expose draft in the template context
- drop unused `mostrar_formulario_epicrisis` flag

## Testing
- `python manage.py test` *(fails: Model class fichaclinica.pacientes.models.Unidad doesn't declare an explicit app_label)*

------
https://chatgpt.com/codex/tasks/task_e_686ffe01eb7c832c82ce2feadc4013f1