### PR TITLE
Fix exportar_epicrisis_pdf attribute error

### DIFF
--- a/pacientes/views.py
+++ b/pacientes/views.py
@@ -319,7 +319,7 @@ def exportar_epicrisis_pdf(request, epicrisis_id):
         'dgegreso': epicrisis.diagnostico_egreso,
         'indicacionesSegunDgPH': epicrisis.indicaciones_generales,
         'indicacionesControles': epicrisis.indicaciones_controles,
-        'medicamentos': epicrisis.medicamentos_indicados.all(),
+        'medicamentos': epicrisis.episodio.medicamentos.all(),
         'peso': getattr(epicrisis, 'peso', ''),
     }
 


### PR DESCRIPTION
## Summary
- pull medications from `epicrisis.episodio` instead of nonexistent `medicamentos_indicados`

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68700c7506a0832c937d537a09885371