### PR TITLE
Add grouped antecedents and include in epicrisis

### DIFF
--- a/pacientes/forms.py
+++ b/pacientes/forms.py
@@ -98,6 +98,34 @@ class AntecedenteForm(forms.ModelForm):
         fields = ['tipo', 'descripcion']
 
 
+class AntecedentesPacienteForm(forms.Form):
+    morbido = forms.CharField(
+        required=False,
+        widget=forms.Textarea(attrs={'rows': 2}),
+        label="Antecedentes mórbidos"
+    )
+    quirurgico = forms.CharField(
+        required=False,
+        widget=forms.Textarea(attrs={'rows': 2}),
+        label="Antecedentes quirúrgicos"
+    )
+    alergia = forms.CharField(
+        required=False,
+        widget=forms.Textarea(attrs={'rows': 2}),
+        label="Alergias"
+    )
+    familiar = forms.CharField(
+        required=False,
+        widget=forms.Textarea(attrs={'rows': 2}),
+        label="Antecedentes familiares"
+    )
+    otro = forms.CharField(
+        required=False,
+        widget=forms.Textarea(attrs={'rows': 2}),
+        label="Otros antecedentes"
+    )
+
+
 from .models import Epicrisis
 
 class EpicrisisForm(forms.ModelForm):


### PR DESCRIPTION
## Summary
- support entering all antecedent types at once via a new form
- store these antecedents as part of each patient
- display patient antecedents in the epicrisis view and PDF
- test that antecedents appear in the epicrisis output

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68702bcdff44832c9fbc8e42cc728649