### PR TITLE
Group antecedentes by type

### DIFF
--- a/pacientes/templates/pacientes/detalle_paciente.html
+++ b/pacientes/templates/pacientes/detalle_paciente.html
@@ -109,7 +109,24 @@
 
         <!-- Antecedentes -->
         <div class="tab-pane fade" id="antecedentes">
-            <div class="card mb-4 shadow-sm">
+            {% for tipo, label in tipo_labels.items %}
+                <h5 class="mt-3">{{ label }}</h5>
+                {% with antecedentes_por_tipo[tipo] as lista %}
+                    {% if lista %}
+                        {% for ant in lista %}
+                            <div class="card mb-2">
+                                <div class="card-body">
+                                    {{ ant.descripcion }}
+                                </div>
+                            </div>
+                        {% endfor %}
+                    {% else %}
+                        <p class="text-muted">No hay antecedentes registrados.</p>
+                    {% endif %}
+                {% endwith %}
+            {% endfor %}
+
+            <div class="card mb-4 shadow-sm mt-4">
                 <div class="card-header">
                     <h5 class="mb-0">Agregar Antecedente</h5>
                 </div>
@@ -122,16 +139,6 @@
                     </form>
                 </div>
             </div>
-
-            {% for ant in antecedentes %}
-                <div class="card mb-2">
-                    <div class="card-body">
-                        <strong>{{ ant.get_tipo_display }}:</strong> {{ ant.descripcion }}
-                    </div>
-                </div>
-            {% empty %}
-                <p class="text-muted">No hay antecedentes registrados.</p>
-            {% endfor %}
         </div>
 
         <!-- Interconsultas -->

--- a/pacientes/views.py
+++ b/pacientes/views.py
@@ -89,6 +89,11 @@ def detalle_paciente(request, paciente_id):
     formset = MedicamentoFormSet(request.POST or None, instance=episodio_activo) if episodio_activo else None
     antecedentes_form = AntecedentesPacienteForm()
     antecedentes = paciente.antecedentes.all()
+    antecedentes_por_tipo = {
+        tipo: antecedentes.filter(tipo=tipo)
+        for tipo, _ in Antecedente.TIPO_CHOICES
+    }
+    tipo_labels = {tipo: label for tipo, label in Antecedente.TIPO_CHOICES}
 
     if request.method == 'POST':
         accion = request.POST.get('accion')
@@ -147,6 +152,8 @@ def detalle_paciente(request, paciente_id):
         'formset': formset,
         'antecedente_form': antecedentes_form,
         'antecedentes': antecedentes,
+        'antecedentes_por_tipo': antecedentes_por_tipo,
+        'tipo_labels': tipo_labels,
         'epicrisis_form': epicrisis_form,
         'epicrisis_existente': epicrisis_existente,
     }


### PR DESCRIPTION
## Summary
- group existing antecedentes by type in `detalle_paciente` view
- show antecedente form below list grouped by type

## Testing
- `python manage.py test -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68702ec8377c832cb5d5e86be7111d2b