### PR TITLE
Implementa generación de PDF en recetas

### DIFF
--- a/pacientes/forms.py
+++ b/pacientes/forms.py
@@ -92,6 +92,10 @@ class RecetaForm(forms.ModelForm):
         fields = ['medicamento', 'dosis', 'frecuencia', 'duracion', 'indicaciones_extra']
 
 
+class RecetaPDFForm(forms.Form):
+    dias_tratamiento = forms.CharField(label="Días de tratamiento", required=False)
+
+
 class AntecedenteForm(forms.ModelForm):
     class Meta:
         model = Antecedente

--- a/pacientes/templates/pacientes/crear_receta.html
+++ b/pacientes/templates/pacientes/crear_receta.html
@@ -1,6 +1,21 @@
-<h3>Crear Receta Médica para {{ paciente.nombre }}</h3>
-<form method="POST">
+{% extends 'base.html' %}
+
+{% block content %}
+<h3>Crear Receta para {{ paciente.nombre }}</h3>
+<form method="post">
     {% csrf_token %}
     {{ form.as_p }}
-    <button type="submit">Crear Receta</button>
+    <button type="submit" class="btn btn-primary">Generar PDF</button>
 </form>
+
+<h5 class="mt-4">Medicamentos guardados</h5>
+{% if medicamentos %}
+<ul>
+    {% for med in medicamentos %}
+    <li>{{ med.nombre }} - {{ med.dosis }}, {{ med.frecuencia }}, vía {{ med.via }}</li>
+    {% endfor %}
+</ul>
+{% else %}
+<p>No hay medicamentos registrados.</p>
+{% endif %}
+{% endblock %}

--- a/pacientes/templates/pacientes/receta_pdf.html
+++ b/pacientes/templates/pacientes/receta_pdf.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body { font-family: Arial, sans-serif; font-size: 12pt; }
+        table { width: 100%; border-collapse: collapse; margin-top: 10px; }
+        th, td { border: 1px solid #000; padding: 4px; text-align: left; }
+    </style>
+</head>
+<body>
+    <div style="text-align:center;">
+        <img src="{{ logo_url }}" alt="Logo" style="height:60px;">
+        <h2>Receta Médica</h2>
+    </div>
+    <p><strong>Nombre:</strong> {{ paciente.nombre }}</p>
+    <p><strong>Edad:</strong> {{ edad }}</p>
+    <p><strong>RUT:</strong> {{ paciente.rut }}</p>
+    <p><strong>Ficha:</strong> {{ paciente.ficha }}</p>
+    <p><strong>Diagnóstico de ingreso:</strong> {{ paciente.diagnostico }}</p>
+    <p><strong>Cama:</strong> {{ paciente.cama.numero|default:"" }}</p>
+    {% if dias_tratamiento %}
+    <p><strong>Días de tratamiento:</strong> {{ dias_tratamiento }}</p>
+    {% endif %}
+    <table>
+        <thead>
+            <tr>
+                <th>Medicamento</th>
+                <th>Dosis</th>
+                <th>Frecuencia</th>
+                <th>Vía</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for med in medicamentos %}
+            <tr>
+                <td>{{ med.nombre }}</td>
+                <td>{{ med.dosis }}</td>
+                <td>{{ med.frecuencia }}</td>
+                <td>{{ med.via }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/pacientes/views.py
+++ b/pacientes/views.py
@@ -21,6 +21,7 @@ from .forms import (
     InterconsultaForm,
     PacienteForm,
     RecetaForm,
+    RecetaPDFForm,
     SolicitudExamenForm,
     EpicrisisForm,
     MedicamentoFormSet,
@@ -244,18 +245,33 @@ def solicitar_examenes(request, paciente_id):
 @login_required
 def crear_receta(request, paciente_id):
     paciente = get_object_or_404(Paciente, id=paciente_id)
-    if request.method == 'POST':
-        form = RecetaForm(request.POST)
-        if form.is_valid():
-            receta = form.save(commit=False)
-            receta.paciente = paciente
-            receta.medico = request.user.perfilusuario
-            receta.save()
-            return redirect('detalle_paciente', paciente_id=paciente_id)
-    else:
-        form = RecetaForm()
+    episodio_activo = paciente.episodios.filter(fecha_egreso__isnull=True).first()
+    medicamentos = episodio_activo.medicamentos.all() if episodio_activo else []
 
-    return render(request, 'pacientes/crear_receta.html', {'form': form, 'paciente': paciente})
+    if request.method == 'POST':
+        form = RecetaPDFForm(request.POST)
+        if form.is_valid():
+            dias = form.cleaned_data.get('dias_tratamiento')
+            context = {
+                'paciente': paciente,
+                'edad': paciente.edad(),
+                'dias_tratamiento': dias,
+                'medicamentos': medicamentos,
+                'logo_url': request.build_absolute_uri(static('img/logo.png')),
+            }
+            html_string = render_to_string('pacientes/receta_pdf.html', context)
+            pdf = HTML(string=html_string, base_url=request.build_absolute_uri()).write_pdf()
+            response = HttpResponse(pdf, content_type='application/pdf')
+            response['Content-Disposition'] = f'attachment; filename="receta_{paciente.id}.pdf"'
+            return response
+    else:
+        form = RecetaPDFForm()
+
+    return render(request, 'pacientes/crear_receta.html', {
+        'form': form,
+        'paciente': paciente,
+        'medicamentos': medicamentos,
+    })
 
 @login_required
 def inicio(request):


### PR DESCRIPTION
## Summary
- agrega formulario `RecetaPDFForm`
- modifica vista `crear_receta` para generar un PDF con los medicamentos guardados
- añade plantilla HTML para el PDF de receta
- renueva la plantilla de creación de receta

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68704aba4370832c8fa32a0909dfe238