### PR TITLE
Fix template syntax error in receta PDF

### DIFF
--- a/pacientes/templates/pacientes/receta_pdf.html
+++ b/pacientes/templates/pacientes/receta_pdf.html
@@ -18,7 +18,9 @@
     <p><strong>RUT:</strong> {{ paciente.rut }}</p>
     <p><strong>Ficha:</strong> {{ paciente.ficha }}</p>
     <p><strong>Diagnóstico de ingreso:</strong> {{ paciente.diagnostico }}</p>
-    <p><strong>Cama:</strong> {{ paciente.cama.numero if paciente.cama }}</p>
+    <p><strong>Cama:</strong>
+        {% if paciente.cama %}{{ paciente.cama.numero }}{% else %}{% endif %}
+    </p>
     <p><strong>Días de tratamiento:</strong> {{ dias_tratamiento }}</p>
 
     <h2>Medicamentos</h2>


### PR DESCRIPTION
## Summary
- fix invalid inline `if` logic in `receta_pdf.html`

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_68727bda08b8832c8f116dfcba9fab10