### PR TITLE
Add Estudios section to main menu

### DIFF
--- a/pacientes/templates/pacientes/estudios.html
+++ b/pacientes/templates/pacientes/estudios.html
@@ -1,0 +1,59 @@
+{% extends 'base.html' %}
+
+{% block extra_css %}
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+{% endblock %}
+
+{% block content %}
+<div class="container mt-4">
+    <h1 class="mb-4">Estudios</h1>
+    <div class="row g-4">
+        <div class="col-md-6 col-lg-3">
+            <a href="https://10.6.119.118/ZFP" class="text-decoration-none text-dark" target="_blank">
+                <div class="card text-center shadow-sm h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">Imagenología</h5>
+                    </div>
+                </div>
+            </a>
+        </div>
+        <div class="col-md-6 col-lg-3">
+            <a href="http://laboratorio.hcsba.cl/" class="text-decoration-none text-dark" target="_blank">
+                <div class="card text-center shadow-sm h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">Laboratorio</h5>
+                    </div>
+                </div>
+            </a>
+        </div>
+        <div class="col-md-6 col-lg-3">
+            <a href="http://10.68.174.40:8002" class="text-decoration-none text-dark" target="_blank">
+                <div class="card text-center shadow-sm h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">Anatomía Patológica</h5>
+                    </div>
+                </div>
+            </a>
+        </div>
+        <div class="col-md-6 col-lg-3">
+            <a href="http://10.6.15.15" class="text-decoration-none text-dark" target="_blank">
+                <div class="card text-center shadow-sm h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">Autoconsulta</h5>
+                    </div>
+                </div>
+            </a>
+        </div>
+        <div class="col-md-6 col-lg-3">
+            <a href="#" class="text-decoration-none text-dark">
+                <div class="card text-center shadow-sm h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">Anexos</h5>
+                    </div>
+                </div>
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/pacientes/templates/pacientes/inicio.html
+++ b/pacientes/templates/pacientes/inicio.html
@@ -67,6 +67,18 @@
                 </div>
             </a>
         </div>
+
+        <!-- Estudios -->
+        <div class="col-md-6 col-lg-3">
+            <a href="{% url 'estudios' %}" class="text-decoration-none text-dark">
+                <div class="card text-center shadow-sm h-100">
+                    <div class="card-body">
+                        <i class="fas fa-file-medical fa-2x mb-3 text-secondary"></i>
+                        <h5 class="card-title">Estudios</h5>
+                    </div>
+                </div>
+            </a>
+        </div>
     </div>
 
 </div>

--- a/pacientes/urls.py
+++ b/pacientes/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
     path('pacientes/<int:paciente_id>/alta/', views.dar_de_alta_paciente, name='dar_de_alta_paciente'),
     path('antecedentes/<int:antecedente_id>/eliminar/', views.eliminar_antecedente, name='eliminar_antecedente'),
     path('buscar/', views.buscar_pacientes, name='buscar_pacientes'),
+    path('estudios/', views.estudios, name='estudios'),
     path('ajax/cargar-opciones-medicamento/', views.cargar_opciones_medicamento, name='cargar_opciones_medicamento'),
     path('api/medicamento-catalogo/<int:pk>/', views.obtener_datos_catalogo, name='obtener_datos_catalogo'),
 ]

--- a/pacientes/views.py
+++ b/pacientes/views.py
@@ -301,6 +301,11 @@ def inicio(request):
     return render(request, 'pacientes/inicio.html')
 
 
+@login_required
+def estudios(request):
+    return render(request, 'pacientes/estudios.html')
+
+
 
 
 


### PR DESCRIPTION
## Summary
- add Estudios card in main menu
- create Estudios page with external link cards
- wire new view and URL

## Testing
- `python3 manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687722a366d0832cb640a353d5755067