### PR TITLE
Improve epicrisis workflow and UI

### DIFF
--- a/pacientes/forms.py
+++ b/pacientes/forms.py
@@ -251,12 +251,26 @@ class SignoVitalForm(forms.ModelForm):
             'saturacion',
         ]
         widgets = {
-            'fecha': forms.DateTimeInput(attrs={'type': 'datetime-local', 'class': 'form-control'}),
-            'temperatura': forms.NumberInput(attrs={'step': '0.1', 'class': 'form-control'}),
-            'presion_arterial': forms.TextInput(attrs={'class': 'form-control'}),
-            'frecuencia_cardiaca': forms.NumberInput(attrs={'class': 'form-control'}),
-            'frecuencia_respiratoria': forms.NumberInput(attrs={'class': 'form-control'}),
-            'saturacion': forms.NumberInput(attrs={'class': 'form-control'}),
+            'fecha': forms.DateTimeInput(attrs={
+                'type': 'datetime-local',
+                'class': 'form-control form-control-sm'
+            }),
+            'temperatura': forms.NumberInput(attrs={
+                'step': '0.1',
+                'class': 'form-control form-control-sm'
+            }),
+            'presion_arterial': forms.TextInput(attrs={
+                'class': 'form-control form-control-sm'
+            }),
+            'frecuencia_cardiaca': forms.NumberInput(attrs={
+                'class': 'form-control form-control-sm'
+            }),
+            'frecuencia_respiratoria': forms.NumberInput(attrs={
+                'class': 'form-control form-control-sm'
+            }),
+            'saturacion': forms.NumberInput(attrs={
+                'class': 'form-control form-control-sm'
+            }),
         }
 
 

--- a/pacientes/static/css/styles.css
+++ b/pacientes/static/css/styles.css
@@ -50,3 +50,12 @@ li:hover {
     text-decoration: none;
     border-radius: 8px;
 }
+
+.section-nav {
+    max-width: 180px;
+}
+
+#miTab .nav-link {
+    border-radius: 0;
+    margin-bottom: 4px;
+}

--- a/pacientes/templates/pacientes/detalle_paciente.html
+++ b/pacientes/templates/pacientes/detalle_paciente.html
@@ -37,7 +37,7 @@
 {% endif %}
 
 <div class="row">
-  <div class="col-md-3 mb-3">
+  <div class="col-md-2 mb-3 section-nav">
     <ul class="nav nav-pills flex-column" id="miTab" role="tablist">
         <li class="nav-item">
             <a class="nav-link active" id="evoluciones-tab" data-bs-toggle="tab" href="#evoluciones">Todas las Evoluciones</a>
@@ -407,8 +407,35 @@
                     <form method="post" id="form-signos">
                         {% csrf_token %}
                         <input type="hidden" name="accion" value="guardar_signos">
-                        {{ signos_form.as_p }}
-                        <button type="submit" class="btn btn-primary btn-sm">Guardar</button>
+                        <div class="row g-2 align-items-end">
+                            <div class="col-md-4">
+                                {{ signos_form.fecha.label_tag }}
+                                {{ signos_form.fecha }}
+                            </div>
+                            <div class="col-md-2">
+                                {{ signos_form.temperatura.label_tag }}
+                                {{ signos_form.temperatura }}
+                            </div>
+                            <div class="col-md-2">
+                                {{ signos_form.presion_arterial.label_tag }}
+                                {{ signos_form.presion_arterial }}
+                            </div>
+                            <div class="col-md-2">
+                                {{ signos_form.frecuencia_cardiaca.label_tag }}
+                                {{ signos_form.frecuencia_cardiaca }}
+                            </div>
+                            <div class="col-md-2">
+                                {{ signos_form.frecuencia_respiratoria.label_tag }}
+                                {{ signos_form.frecuencia_respiratoria }}
+                            </div>
+                            <div class="col-md-2">
+                                {{ signos_form.saturacion.label_tag }}
+                                {{ signos_form.saturacion }}
+                            </div>
+                            <div class="col-md-2">
+                                <button type="submit" class="btn btn-primary btn-sm w-100">Guardar</button>
+                            </div>
+                        </div>
                     </form>
                 </div>
             </div>

--- a/pacientes/templates/pacientes/solicitar_examenes.html
+++ b/pacientes/templates/pacientes/solicitar_examenes.html
@@ -1,16 +1,29 @@
-<h3>Solicitar Exámenes para {{ paciente.nombre }}</h3>
-<form method="POST" id="form-examen">
-    {% csrf_token %}
-    {{ form.categoria.label_tag }}
-    {{ form.categoria }}
-    <br>
-    {{ form.tipo_examen.label_tag }}
-    {{ form.tipo_examen }}
-    <br>
-    {{ form.indicaciones.label_tag }}
-    {{ form.indicaciones }}
-    <button type="submit" class="btn btn-primary mt-2">Solicitar Examen</button>
-</form>
+{% extends 'base.html' %}
+
+{% block content %}
+<h3 class="mb-3">Solicitar Exámenes para {{ paciente.nombre }}</h3>
+<div class="card shadow-sm">
+    <div class="card-body">
+        <form method="POST" id="form-examen" class="row g-3">
+            {% csrf_token %}
+            <div class="col-md-4">
+                {{ form.categoria.label_tag }}
+                {{ form.categoria }}
+            </div>
+            <div class="col-md-4">
+                {{ form.tipo_examen.label_tag }}
+                {{ form.tipo_examen }}
+            </div>
+            <div class="col-12">
+                {{ form.indicaciones.label_tag }}
+                {{ form.indicaciones }}
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Solicitar Examen</button>
+            </div>
+        </form>
+    </div>
+</div>
 
 {{ IMAGENES|json_script:"imagenes-data" }}
 {{ LABORATORIO|json_script:"laboratorio-data" }}
@@ -36,3 +49,5 @@
   categoriaSelect.addEventListener('change', cargarOpciones);
   document.addEventListener('DOMContentLoaded', cargarOpciones);
 </script>
+
+{% endblock %}

--- a/pacientes/views.py
+++ b/pacientes/views.py
@@ -411,10 +411,13 @@ def crear_epicrisis(request, paciente_id):
             epicrisis = form.save(commit=False)
             epicrisis.episodio = episodio
             epicrisis.autor = request.user
-            if request.POST.get('accion') == 'finalizar':
+            finalizar = request.POST.get('accion') == 'finalizar'
+            if finalizar:
                 epicrisis.finalizado = True
             epicrisis.save()
             messages.success(request, "Epicrisis creada correctamente.")
+            if finalizar:
+                return redirect('exportar_epicrisis_pdf', epicrisis_id=epicrisis.id)
             return redirect('detalle_paciente', paciente_id)
     else:
         form = EpicrisisForm()


### PR DESCRIPTION
## Summary
- redirect to PDF when finishing a new epicrisis
- make section sidebar narrower and tidy
- display vital-sign fields compactly
- style exam request form with Bootstrap
- shrink vital sign inputs via form-control-sm

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687dad3ff1fc832ca8c4705bc0c6644e