### PR TITLE
Fix tabs resetting after form submissions

### DIFF
--- a/pacientes/templates/pacientes/detalle_paciente.html
+++ b/pacientes/templates/pacientes/detalle_paciente.html
@@ -737,4 +737,23 @@ document.addEventListener('DOMContentLoaded', function(){
 });
 </script>
 
+<script>
+// Mantener pestaña activa tras recargar la página
+document.addEventListener('DOMContentLoaded', function () {
+    const tabLinks = document.querySelectorAll('#miTab a[data-bs-toggle="tab"]');
+    if (!tabLinks.length) return;
+    const storageKey = 'activeTab-' + window.location.pathname;
+    const storedTab = localStorage.getItem(storageKey);
+    if (storedTab) {
+        const someTab = document.querySelector(`#miTab a[href="${storedTab}"]`);
+        if (someTab) new bootstrap.Tab(someTab).show();
+    }
+    tabLinks.forEach(link => {
+        link.addEventListener('shown.bs.tab', e => {
+            localStorage.setItem(storageKey, e.target.getAttribute('href'));
+        });
+    });
+});
+</script>
+
 {% endblock %}

--- a/pacientes/templates/pacientes/interconsultas_recibidas.html
+++ b/pacientes/templates/pacientes/interconsultas_recibidas.html
@@ -52,4 +52,23 @@
   </div>
 
 </div>
+
+<script>
+// Mantener la pestaña activa tras recarga
+document.addEventListener('DOMContentLoaded', function () {
+    const tabLinks = document.querySelectorAll('#interconsultaTabs button[data-bs-toggle="tab"]');
+    if (!tabLinks.length) return;
+    const storageKey = 'activeTab-' + window.location.pathname;
+    const storedTab = localStorage.getItem(storageKey);
+    if (storedTab) {
+        const targetBtn = document.querySelector(`#interconsultaTabs button[data-bs-target="${storedTab}"]`);
+        if (targetBtn) new bootstrap.Tab(targetBtn).show();
+    }
+    tabLinks.forEach(btn => {
+        btn.addEventListener('shown.bs.tab', e => {
+            localStorage.setItem(storageKey, e.target.getAttribute('data-bs-target'));
+        });
+    });
+});
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- keep patient's active tab after page reload
- persist active tab on interconsultas view

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687e346bd7c0832c948a1e414165cc85