### PR TITLE
Agrupar examenes solicitados y poder imprimir registro

### DIFF
--- a/pacientes/migrations/0007_rename_tipo_examen_examenes.py
+++ b/pacientes/migrations/0007_rename_tipo_examen_examenes.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('pacientes', '0006_solicitudexamen_categoria_evaluacionenfermeria_and_more'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='solicitudexamen',
+            old_name='tipo_examen',
+            new_name='examenes',
+        ),
+        migrations.AlterField(
+            model_name='solicitudexamen',
+            name='examenes',
+            field=models.TextField(),
+        ),
+    ]

--- a/pacientes/models.py
+++ b/pacientes/models.py
@@ -154,15 +154,32 @@ class Interconsulta(models.Model):
 
 
 class SolicitudExamen(models.Model):
-    paciente = models.ForeignKey('Paciente', on_delete=models.CASCADE, related_name='solicitudes_examenes')
-    solicitante = models.ForeignKey(PerfilUsuario, on_delete=models.PROTECT, related_name='examenes_solicitados')
-    categoria = models.CharField(max_length=20, choices=[('imagen', 'Imagenología'), ('laboratorio', 'Laboratorio')], default='laboratorio')
-    tipo_examen = models.CharField(max_length=100)
+    paciente = models.ForeignKey(
+        "Paciente",
+        on_delete=models.CASCADE,
+        related_name="solicitudes_examenes",
+    )
+    solicitante = models.ForeignKey(
+        PerfilUsuario,
+        on_delete=models.PROTECT,
+        related_name="examenes_solicitados",
+    )
+    categoria = models.CharField(
+        max_length=20,
+        choices=[("imagen", "Imagenología"), ("laboratorio", "Laboratorio")],
+        default="laboratorio",
+    )
+    examenes = models.TextField()
     indicaciones = models.TextField(blank=True, null=True)
     fecha_solicitud = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
-        return f"{self.tipo_examen} solicitado por {self.solicitante} para {self.paciente}"
+        return (
+            f"{self.paciente} - {self.categoria} ({self.fecha_solicitud:%d/%m/%Y})"
+        )
+
+    def lista_examenes(self):
+        return [e for e in self.examenes.splitlines() if e]
 
 
 class Receta(models.Model):

--- a/pacientes/templates/pacientes/detalle_paciente.html
+++ b/pacientes/templates/pacientes/detalle_paciente.html
@@ -195,12 +195,18 @@
         <div class="tab-pane fade" id="examenes">
             <p><a href="{% url 'solicitar_examenes' paciente.id %}" class="btn btn-primary mb-3">Solicitar Exámenes</a></p>
             {% if paciente.solicitudes_examenes.all %}
-                {% for examen in paciente.solicitudes_examenes.all %}
+                {% for solicitud in paciente.solicitudes_examenes.all %}
                     <div class="card mb-2">
                         <div class="card-body">
-                            <p><strong>Tipo:</strong> {{ examen.tipo_examen }}</p>
-                            <p><strong>Indicaciones:</strong> {{ examen.indicaciones|default:"Sin indicaciones" }}</p>
-                            <p><strong>Fecha:</strong> {{ examen.fecha_solicitud|date:"d/m/Y H:i" }}</p>
+                            <p><strong>Categoría:</strong> {{ solicitud.categoria|title }}</p>
+                            <p><strong>Indicaciones:</strong> {{ solicitud.indicaciones|default:"Sin indicaciones" }}</p>
+                            <p><strong>Fecha:</strong> {{ solicitud.fecha_solicitud|date:"d/m/Y H:i" }}</p>
+                            <ul>
+                                {% for ex in solicitud.examenes.splitlines %}
+                                    <li>{{ ex }}</li>
+                                {% endfor %}
+                            </ul>
+                            <a href="{% url 'imprimir_solicitud_examen' solicitud.id %}" class="btn btn-sm btn-secondary">Imprimir</a>
                         </div>
                     </div>
                 {% endfor %}

--- a/pacientes/urls.py
+++ b/pacientes/urls.py
@@ -10,6 +10,11 @@ urlpatterns = [
     path('pacientes/<int:paciente_id>/exportar_pdf/', views.exportar_pdf, name='exportar_pdf'),
     path('pacientes/<int:paciente_id>/interconsulta/', views.crear_interconsulta, name='crear_interconsulta'),
     path('pacientes/<int:paciente_id>/examenes/', views.solicitar_examenes, name='solicitar_examenes'),
+    path(
+        'solicitudes-examen/<int:solicitud_id>/imprimir/',
+        views.imprimir_solicitud_examen,
+        name='imprimir_solicitud_examen',
+    ),
     path('pacientes/<int:paciente_id>/receta/', views.crear_receta, name='crear_receta'),
     path('pacientes/<int:paciente_id>/epicrisis/nueva/', views.crear_epicrisis, name='crear_epicrisis'),
     path('episodios/<int:episodio_id>/', views.detalle_episodio, name='detalle_episodio'),


### PR DESCRIPTION
## Summary
- rename `tipo_examen` to `examenes` and allow storing multiple tests
- store the list of exams in a single `SolicitudExamen`
- add view and URL to print a saved exam request
- show grouped exam list with print button on patient detail
- migration for renaming the field

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687e3b652624832c9006a82a646e9ee9