### PR TITLE
Improve exam request UI

### DIFF
--- a/pacientes/forms.py
+++ b/pacientes/forms.py
@@ -114,7 +114,9 @@ class SolicitudExamenForm(forms.Form):
         label='Sección'
     )
     tipo_examen = forms.MultipleChoiceField(
-        choices=[], label='Exámenes'
+        choices=[],
+        label='Exámenes',
+        widget=forms.CheckboxSelectMultiple,
     )
     indicaciones = forms.CharField(
         widget=forms.Textarea, required=False, label='Indicaciones'

--- a/pacientes/templates/pacientes/solicitar_examenes.html
+++ b/pacientes/templates/pacientes/solicitar_examenes.html
@@ -10,7 +10,7 @@
                 {{ form.categoria.label_tag }}
                 {{ form.categoria }}
             </div>
-            <div class="col-md-4">
+            <div class="col-md-8" id="examenes-wrapper">
                 {{ form.tipo_examen.label_tag }}
                 {{ form.tipo_examen }}
             </div>
@@ -33,16 +33,24 @@
     'laboratorio': JSON.parse(document.getElementById('laboratorio-data').textContent)
   };
   const categoriaSelect = document.getElementById('id_categoria');
-  const examenSelect = document.getElementById('id_tipo_examen');
+  const examenContainer = document.getElementById('id_tipo_examen');
 
   function cargarOpciones() {
     const cat = categoriaSelect.value;
-    examenSelect.innerHTML = '';
-    opciones[cat].forEach(opt => {
-      const o = document.createElement('option');
-      o.value = opt;
-      o.textContent = opt;
-      examenSelect.appendChild(o);
+    examenContainer.innerHTML = '';
+    opciones[cat].forEach((opt, idx) => {
+      const li = document.createElement('li');
+      const label = document.createElement('label');
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.name = 'tipo_examen';
+      input.value = opt;
+      input.id = `id_tipo_examen_${idx}`;
+      label.htmlFor = input.id;
+      label.appendChild(input);
+      label.append(` ${opt}`);
+      li.appendChild(label);
+      examenContainer.appendChild(li);
     });
   }
 


### PR DESCRIPTION
## Summary
- update exam request form to use checkboxes for easier multi-selection
- adjust JavaScript in template to dynamically build checkbox list

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687e3c6e0acc832cb028b4979034b53c