### PR TITLE
Add modal for templates

### DIFF
--- a/pacientes/templates/epicrisis/crear_epicrisis.html
+++ b/pacientes/templates/epicrisis/crear_epicrisis.html
@@ -16,10 +16,10 @@
     <div class="mb-3">
       {{ form.indicaciones_generales.label_tag }}
       {{ form.indicaciones_generales }}
-      <div class="mt-1 d-flex gap-2">
-        <select id="plantillas-indicaciones-gen" class="form-select form-select-sm"></select>
-        <button type="button" class="btn btn-secondary btn-sm" onclick="aplicarPlantilla('indicacion_general')">Usar</button>
-        <button type="button" class="btn btn-outline-secondary btn-sm" onclick="guardarPlantilla('indicacion_general', document.getElementById('id_indicaciones_generales').value)">Guardar actual</button>
+      <div class="mt-1">
+        <button type="button" class="btn btn-link p-0" onclick="openPlantillaModal('indicacion_general','id_indicaciones_generales')" title="Plantillas">
+          <i class="bi bi-card-text fs-5"></i>
+        </button>
       </div>
     </div>
     <div class="mb-2">
@@ -34,20 +34,4 @@
       Finalizar y Generar PDF
     </button>
   </form>
-<script>
-document.addEventListener('DOMContentLoaded',function(){
-    const endpoint='{% url "obtener_plantillas" %}';
-    const guardar='{% url "guardar_plantilla" %}';
-    function cargar(){
-        fetch(`${endpoint}?tipo=indicacion_general`).then(r=>r.json()).then(d=>{
-            const sel=document.getElementById('plantillas-indicaciones-gen');
-            sel.innerHTML='';
-            d.plantillas.forEach(p=>{const o=document.createElement('option');o.value=p.contenido;o.textContent=p.titulo||p.contenido.substring(0,30);sel.appendChild(o);});
-        });
-    }
-    cargar();
-    window.aplicarPlantilla=function(){const sel=document.getElementById('plantillas-indicaciones-gen');document.getElementById('id_indicaciones_generales').value=sel.value;};
-    window.guardarPlantilla=function(){const val=document.getElementById('id_indicaciones_generales').value;fetch(guardar,{method:'POST',headers:{'X-CSRFToken':'{{ csrf_token }}','Content-Type':'application/x-www-form-urlencoded'},body:new URLSearchParams({tipo:'indicacion_general',contenido:val})}).then(cargar);};
-});
-</script>
 {% endblock %}

--- a/pacientes/templates/epicrisis/editar_epicrisis.html
+++ b/pacientes/templates/epicrisis/editar_epicrisis.html
@@ -16,10 +16,10 @@
     <div class="mb-3">
         {{ form.indicaciones_generales.label_tag }}
         {{ form.indicaciones_generales }}
-        <div class="mt-1 d-flex gap-2">
-            <select id="plantillas-indicaciones-gen" class="form-select form-select-sm"></select>
-            <button type="button" class="btn btn-secondary btn-sm" onclick="aplicarPlantilla('indicacion_general')">Usar</button>
-            <button type="button" class="btn btn-outline-secondary btn-sm" onclick="guardarPlantilla('indicacion_general', document.getElementById('id_indicaciones_generales').value)">Guardar actual</button>
+        <div class="mt-1">
+            <button type="button" class="btn btn-link p-0" onclick="openPlantillaModal('indicacion_general','id_indicaciones_generales')" title="Plantillas">
+                <i class="bi bi-card-text fs-5"></i>
+            </button>
         </div>
     </div>
     <div class="mb-2">
@@ -31,22 +31,7 @@
     <button type="submit" name="accion" value="finalizar" class="btn btn-primary">Finalizar y generar PDF</button>
 </form>
 
-<script>
-document.addEventListener('DOMContentLoaded',function(){
-    const endpoint='{% url "obtener_plantillas" %}';
-    const guardar='{% url "guardar_plantilla" %}';
-    function cargar(){
-        fetch(`${endpoint}?tipo=indicacion_general`).then(r=>r.json()).then(d=>{
-            const sel=document.getElementById('plantillas-indicaciones-gen');
-            sel.innerHTML='';
-            d.plantillas.forEach(p=>{const o=document.createElement('option');o.value=p.contenido;o.textContent=p.titulo||p.contenido.substring(0,30);sel.appendChild(o);});
-        });
-    }
-    cargar();
-    window.aplicarPlantilla=function(){const sel=document.getElementById('plantillas-indicaciones-gen');document.getElementById('id_indicaciones_generales').value=sel.value;};
-    window.guardarPlantilla=function(){const val=document.getElementById('id_indicaciones_generales').value;fetch(guardar,{method:'POST',headers:{'X-CSRFToken':'{{ csrf_token }}','Content-Type':'application/x-www-form-urlencoded'},body:new URLSearchParams({tipo:'indicacion_general',contenido:val})}).then(cargar);};
-});
-</script>
+
 
 <p class="mt-4">
     <a href="{% url 'detalle_paciente' epicrisis.paciente.id %}">← Volver a ficha del paciente</a>

--- a/pacientes/templates/pacientes/detalle_paciente.html
+++ b/pacientes/templates/pacientes/detalle_paciente.html
@@ -83,10 +83,10 @@
         {% csrf_token %}
         <input type="hidden" name="accion" value="guardar_evolucion">
 
-        <div class="mb-2 d-flex align-items-center gap-2">
-          <select id="plantillas-evolucion" class="form-select form-select-sm"></select>
-          <button type="button" class="btn btn-secondary btn-sm" onclick="aplicarPlantilla('evolucion')">Usar</button>
-          <button type="button" class="btn btn-outline-secondary btn-sm" onclick="guardarPlantilla('evolucion', document.getElementById('id_contenido').value)">Guardar actual</button>
+        <div class="mb-2">
+          <button type="button" class="btn btn-link p-0" onclick="openPlantillaModal('evolucion','id_contenido')" title="Plantillas">
+            <i class="bi bi-card-text fs-5"></i>
+          </button>
         </div>
 
         <div class="mb-3">
@@ -97,10 +97,10 @@
         <div class="mb-3">
           {{ form.plan_indicaciones.label_tag }}
           {{ form.plan_indicaciones }}
-          <div class="mt-1 d-flex align-items-center gap-2">
-            <select id="plantillas-plan" class="form-select form-select-sm"></select>
-            <button type="button" class="btn btn-secondary btn-sm" onclick="aplicarPlantilla('plan')">Usar</button>
-            <button type="button" class="btn btn-outline-secondary btn-sm" onclick="guardarPlantilla('plan', document.getElementById('id_plan_indicaciones').value)">Guardar actual</button>
+          <div class="mt-1">
+            <button type="button" class="btn btn-link p-0" onclick="openPlantillaModal('plan','id_plan_indicaciones')" title="Plantillas">
+              <i class="bi bi-card-text fs-5"></i>
+            </button>
           </div>
         </div>
 
@@ -328,55 +328,55 @@
                         <div class="mb-2">
                             {{ indicacion_form.reposo.label_tag }}
                             {{ indicacion_form.reposo }}
-                            <div class="mt-1 d-flex gap-2">
-                                <select data-field="reposo" class="form-select form-select-sm plantilla-select"></select>
-                                <button type="button" class="btn btn-secondary btn-sm" onclick="aplicarPlantillaCampo('reposo')">Usar</button>
-                                <button type="button" class="btn btn-outline-secondary btn-sm" onclick="guardarPlantillaCampo('reposo')">Guardar</button>
+                            <div class="mt-1">
+                                <button type="button" class="btn btn-link p-0" onclick="openPlantillaModal('indicacion_reposo','id_reposo')" title="Plantillas">
+                                    <i class="bi bi-card-text fs-5"></i>
+                                </button>
                             </div>
                         </div>
                         <div class="mb-2">
                             {{ indicacion_form.regimen.label_tag }}
                             {{ indicacion_form.regimen }}
-                            <div class="mt-1 d-flex gap-2">
-                                <select data-field="regimen" class="form-select form-select-sm plantilla-select"></select>
-                                <button type="button" class="btn btn-secondary btn-sm" onclick="aplicarPlantillaCampo('regimen')">Usar</button>
-                                <button type="button" class="btn btn-outline-secondary btn-sm" onclick="guardarPlantillaCampo('regimen')">Guardar</button>
+                            <div class="mt-1">
+                                <button type="button" class="btn btn-link p-0" onclick="openPlantillaModal('indicacion_regimen','id_regimen')" title="Plantillas">
+                                    <i class="bi bi-card-text fs-5"></i>
+                                </button>
                             </div>
                         </div>
                         <div class="mb-2">
                             {{ indicacion_form.medicamentos.label_tag }}
                             {{ indicacion_form.medicamentos }}
-                            <div class="mt-1 d-flex gap-2">
-                                <select data-field="medicamentos" class="form-select form-select-sm plantilla-select"></select>
-                                <button type="button" class="btn btn-secondary btn-sm" onclick="aplicarPlantillaCampo('medicamentos')">Usar</button>
-                                <button type="button" class="btn btn-outline-secondary btn-sm" onclick="guardarPlantillaCampo('medicamentos')">Guardar</button>
+                            <div class="mt-1">
+                                <button type="button" class="btn btn-link p-0" onclick="openPlantillaModal('indicacion_medicamentos','id_medicamentos')" title="Plantillas">
+                                    <i class="bi bi-card-text fs-5"></i>
+                                </button>
                             </div>
                         </div>
                         <div class="mb-2">
                             {{ indicacion_form.infusiones.label_tag }}
                             {{ indicacion_form.infusiones }}
-                            <div class="mt-1 d-flex gap-2">
-                                <select data-field="infusiones" class="form-select form-select-sm plantilla-select"></select>
-                                <button type="button" class="btn btn-secondary btn-sm" onclick="aplicarPlantillaCampo('infusiones')">Usar</button>
-                                <button type="button" class="btn btn-outline-secondary btn-sm" onclick="guardarPlantillaCampo('infusiones')">Guardar</button>
+                            <div class="mt-1">
+                                <button type="button" class="btn btn-link p-0" onclick="openPlantillaModal('indicacion_infusiones','id_infusiones')" title="Plantillas">
+                                    <i class="bi bi-card-text fs-5"></i>
+                                </button>
                             </div>
                         </div>
                         <div class="mb-2">
                             {{ indicacion_form.dispositivos.label_tag }}
                             {{ indicacion_form.dispositivos }}
-                            <div class="mt-1 d-flex gap-2">
-                                <select data-field="dispositivos" class="form-select form-select-sm plantilla-select"></select>
-                                <button type="button" class="btn btn-secondary btn-sm" onclick="aplicarPlantillaCampo('dispositivos')">Usar</button>
-                                <button type="button" class="btn btn-outline-secondary btn-sm" onclick="guardarPlantillaCampo('dispositivos')">Guardar</button>
+                            <div class="mt-1">
+                                <button type="button" class="btn btn-link p-0" onclick="openPlantillaModal('indicacion_dispositivos','id_dispositivos')" title="Plantillas">
+                                    <i class="bi bi-card-text fs-5"></i>
+                                </button>
                             </div>
                         </div>
                         <div class="mb-3">
                             {{ indicacion_form.otras.label_tag }}
                             {{ indicacion_form.otras }}
-                            <div class="mt-1 d-flex gap-2">
-                                <select data-field="otras" class="form-select form-select-sm plantilla-select"></select>
-                                <button type="button" class="btn btn-secondary btn-sm" onclick="aplicarPlantillaCampo('otras')">Usar</button>
-                                <button type="button" class="btn btn-outline-secondary btn-sm" onclick="guardarPlantillaCampo('otras')">Guardar</button>
+                            <div class="mt-1">
+                                <button type="button" class="btn btn-link p-0" onclick="openPlantillaModal('indicacion_otras','id_otras')" title="Plantillas">
+                                    <i class="bi bi-card-text fs-5"></i>
+                                </button>
                             </div>
                         </div>
                         <button type="submit" class="btn btn-primary">Guardar</button>
@@ -689,58 +689,16 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function(){
-    const plantillaEndpoint = '{% url "obtener_plantillas" %}';
-    const guardarEndpoint = '{% url "guardar_plantilla" %}';
-
-    function cargarSelect(tipo, select){
-        fetch(`${plantillaEndpoint}?tipo=${tipo}`)
-          .then(r=>r.json()).then(data=>{
-            select.innerHTML='';
-            data.plantillas.forEach(p=>{
-                const opt=document.createElement('option');
-                opt.value=p.contenido;
-                opt.textContent=p.titulo||p.contenido.substring(0,30);
-                select.appendChild(opt);
+    window.copiarUltimaIndicacion = function(){
+        fetch('{% url "ultima_indicacion" paciente.id %}')
+            .then(r => r.json())
+            .then(data => {
+                for(const k in data){
+                    const f = document.getElementById('id_'+k);
+                    if(f) f.value = data[k];
+                }
             });
-          });
-    }
-
-    function aplicarPlantilla(tipo){
-        const sel=document.getElementById(`plantillas-${tipo}`);
-        if(!sel) return;
-        if(tipo==='evolucion') document.getElementById('id_contenido').value=sel.value;
-        if(tipo==='plan') document.getElementById('id_plan_indicaciones').value=sel.value;
-        if(tipo==='indicacion_general') document.getElementById('id_indicaciones_generales').value=sel.value;
-    }
-
-    function guardarPlantilla(tipo, contenido){
-        fetch(guardarEndpoint,{method:'POST',headers:{'X-CSRFToken':'{{ csrf_token }}','Content-Type':'application/x-www-form-urlencoded'},body:new URLSearchParams({tipo,contenido})}).then(()=>cargarSelect(tipo,document.getElementById(`plantillas-${tipo}`)));
-    }
-
-    document.querySelectorAll('#plantillas-evolucion,#plantillas-plan,#plantillas-indicaciones-gen').forEach(sel=>{cargarSelect(sel.id.replace('plantillas-',''),sel);});
-
-    function cargarSelectCampo(campo){
-        const sel=document.querySelector(`select[data-field="${campo}"]`); if(sel) cargarSelect(`indicacion_${campo}`, sel);
-    }
-
-    function aplicarPlantillaCampo(campo){
-        const sel=document.querySelector(`select[data-field="${campo}"]`); if(sel) document.getElementById(`id_${campo}`).value=sel.value;
-    }
-
-    function guardarPlantillaCampo(campo){
-        const valor=document.getElementById(`id_${campo}`).value;
-        fetch(guardarEndpoint,{method:'POST',headers:{'X-CSRFToken':'{{ csrf_token }}','Content-Type':'application/x-www-form-urlencoded'},body:new URLSearchParams({tipo:`indicacion_${campo}`,contenido:valor})}).then(()=>cargarSelectCampo(campo));
-    }
-
-    ['reposo','regimen','medicamentos','infusiones','dispositivos','otras'].forEach(c=>cargarSelectCampo(c));
-
-    window.copiarUltimaIndicacion=function(){
-        fetch('{% url "ultima_indicacion" paciente.id %}').then(r=>r.json()).then(data=>{for(const k in data){const f=document.getElementById('id_'+k);if(f) f.value=data[k];}});
     };
-    window.aplicarPlantilla=aplicarPlantilla;
-    window.guardarPlantilla=guardarPlantilla;
-    window.aplicarPlantillaCampo=aplicarPlantillaCampo;
-    window.guardarPlantillaCampo=guardarPlantillaCampo;
 });
 </script>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,7 @@
     <title>{% block title %}Ficha Clínica Electrónica{% endblock %}</title>
     <link rel="stylesheet" href="{% static 'css/footer.css' %}">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     
     {% block extra_css %}{% endblock %}
@@ -69,6 +70,77 @@
             &copy; 2025 <strong>EnRojo</strong> · Hospital Clínico San Borja Arriarán
         </small>
     </footer>
+
+    <!-- Modal para selección de plantillas -->
+    <div class="modal fade" id="modalPlantillas" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Plantillas</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+                </div>
+                <div class="modal-body">
+                    <select id="modal-plantilla-select" class="form-select mb-3"></select>
+                    <div class="d-flex justify-content-end gap-2">
+                        <button type="button" class="btn btn-secondary" id="modal-plantilla-usar">Usar</button>
+                        <button type="button" class="btn btn-outline-secondary" id="modal-plantilla-guardar">Guardar actual</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const plantillaEndpoint = "{% url 'obtener_plantillas' %}";
+        const guardarPlantillaEndpoint = "{% url 'guardar_plantilla' %}";
+        const csrfToken = "{{ csrf_token }}";
+        document.addEventListener('DOMContentLoaded', () => {
+            const modalEl = document.getElementById('modalPlantillas');
+            const modal = new bootstrap.Modal(modalEl);
+            const select = document.getElementById('modal-plantilla-select');
+            const btnUsar = document.getElementById('modal-plantilla-usar');
+            const btnGuardar = document.getElementById('modal-plantilla-guardar');
+            let tipo = null;
+            let campoId = null;
+
+            window.openPlantillaModal = function(t, campo){
+                tipo = t;
+                campoId = campo;
+                cargar();
+                modal.show();
+            };
+
+            function cargar(){
+                fetch(`${plantillaEndpoint}?tipo=${tipo}`)
+                    .then(r => r.json())
+                    .then(d => {
+                        select.innerHTML = '';
+                        d.plantillas.forEach(p => {
+                            const o = document.createElement('option');
+                            o.value = p.contenido;
+                            o.textContent = p.titulo || p.contenido.substring(0,30);
+                            select.appendChild(o);
+                        });
+                    });
+            }
+
+            btnUsar.addEventListener('click', () => {
+                const field = document.getElementById(campoId);
+                if (field) field.value = select.value;
+                modal.hide();
+            });
+
+            btnGuardar.addEventListener('click', () => {
+                const field = document.getElementById(campoId);
+                if (!field) return;
+                fetch(guardarPlantillaEndpoint, {
+                    method: 'POST',
+                    headers: { 'X-CSRFToken': csrfToken, 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: new URLSearchParams({ tipo, contenido: field.value })
+                }).then(cargar);
+            });
+        });
+    </script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use Bootstrap icons and add modal logic to base template
- open modal from epicrisis views
- allow accessing templates from patient detail using modal

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687e3f46cf00832c848fccd19c4117dc