### PR TITLE
Restrict nursing evaluation input by role

### DIFF
--- a/pacientes/templates/pacientes/detalle_paciente.html
+++ b/pacientes/templates/pacientes/detalle_paciente.html
@@ -506,6 +506,7 @@
 
             <hr>
 
+            {% if user.perfilusuario.cargo == "Enfermería" %}
             <div class="card mb-4 shadow-sm">
                 <div class="card-header">
                     <h5 class="mb-0">Evaluación de Enfermería</h5>
@@ -519,6 +520,7 @@
                     </form>
                 </div>
             </div>
+            {% endif %}
 
             {% for ev in evaluaciones %}
                 <div class="card mb-2">


### PR DESCRIPTION
## Summary
- hide the "Evaluación de Enfermería" form unless the logged in user has cargo "Enfermería"

## Testing
- `python manage.py test` *(fails: OperationalError near "None")*

------
https://chatgpt.com/codex/tasks/task_e_687e8f1bfe24832cacb01f421acd2c9f