### PR TITLE
Update epicrisis draft behaviour

### DIFF
--- a/pacientes/tests.py
+++ b/pacientes/tests.py
@@ -114,3 +114,39 @@ class DetalleEpisodioTests(TestCase):
         self.assertContains(response, "nota")
 
 
+class EpicrisisAutorTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="med", password="pw")
+        self.client.login(username="med", password="pw")
+        self.paciente = Paciente.objects.create(nombre="Aut")
+        self.episodio = Episodio.objects.create(paciente=self.paciente)
+
+    def _post_data(self, accion):
+        url = reverse('crear_epicrisis', args=[self.paciente.id])
+        data = {
+            'diagnostico_egreso': 'dg',
+            'comentario_evolucion': 'c',
+            'indicaciones_generales': '',
+            'indicaciones_controles': '',
+            'examenes_pendientes': 'False',
+            'detalle_examenes_pendientes': '',
+            'examenes_realizados': 'False',
+            'detalle_examenes_realizados': '',
+            'condicion_mejorado': 'True',
+            'accion': accion,
+        }
+        self.client.post(url, data)
+
+    def test_borrador_sin_autor(self):
+        self._post_data('guardar')
+        epicrisis = Epicrisis.objects.get(episodio=self.episodio)
+        self.assertIsNone(epicrisis.autor)
+        self.assertFalse(epicrisis.finalizado)
+
+    def test_finalizar_asigna_autor(self):
+        self._post_data('finalizar')
+        epicrisis = Epicrisis.objects.get(episodio=self.episodio)
+        self.assertEqual(epicrisis.autor, self.user)
+        self.assertTrue(epicrisis.finalizado)
+
+

--- a/pacientes/views.py
+++ b/pacientes/views.py
@@ -527,10 +527,10 @@ def crear_epicrisis(request, paciente_id):
         if form.is_valid():
             epicrisis = form.save(commit=False)
             epicrisis.episodio = episodio
-            epicrisis.autor = request.user
             finalizar = request.POST.get('accion') == 'finalizar'
             if finalizar:
                 epicrisis.finalizado = True
+                epicrisis.autor = request.user
             epicrisis.save()
             messages.success(request, "Epicrisis creada correctamente.")
             if finalizar:
@@ -554,9 +554,12 @@ def editar_epicrisis(request, epicrisis_id):
     if request.method == 'POST':
         form = EpicrisisForm(request.POST, instance=epicrisis)
         if form.is_valid():
-            epicrisis = form.save()
-            if request.POST.get('accion') == 'finalizar':
+            epicrisis = form.save(commit=False)
+            finalizar = request.POST.get('accion') == 'finalizar'
+            if finalizar:
                 epicrisis.finalizado = True
+                if epicrisis.autor is None:
+                    epicrisis.autor = request.user
                 episodio = epicrisis.episodio
                 episodio.fecha_egreso = timezone.now()
                 episodio.finalizado = True
@@ -566,6 +569,7 @@ def editar_epicrisis(request, epicrisis_id):
                 epicrisis.paciente.save()
                 epicrisis.save()
                 return redirect('exportar_epicrisis_pdf', epicrisis_id=epicrisis.id)
+            epicrisis.save()
             return redirect('detalle_paciente', paciente_id=epicrisis.paciente.id)
     else:
         form = EpicrisisForm(instance=epicrisis)


### PR DESCRIPTION
## Summary
- keep epicrisis author empty when saving as draft
- assign author only on finalize
- test author field on draft and finalized epicrisis

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687ec6799828832cb29d39e029b5095e