### PR TITLE
Add age suffix

### DIFF
--- a/pacientes/models.py
+++ b/pacientes/models.py
@@ -35,6 +35,29 @@ class Paciente(models.Model):
             )
         return None
 
+    def edad_con_sufijo(self):
+        """Retorna la edad en años o meses con su sufijo correspondiente."""
+        from datetime import date
+
+        if not self.fecha_nacimiento:
+            return ""
+
+        today = date.today()
+
+        years = today.year - self.fecha_nacimiento.year - (
+            (today.month, today.day) < (self.fecha_nacimiento.month, self.fecha_nacimiento.day)
+        )
+        if years > 0:
+            sufijo = "año" if years == 1 else "años"
+            return f"{years} {sufijo}"
+
+        months = (today.year - self.fecha_nacimiento.year) * 12 + today.month - self.fecha_nacimiento.month
+        if today.day < self.fecha_nacimiento.day:
+            months -= 1
+
+        sufijo = "mes" if months == 1 else "meses"
+        return f"{months} {sufijo}"
+
     def __str__(self):
         return f'Ficha {self.ficha} - {self.nombre}'
     

--- a/pacientes/templates/pacientes/detalle_paciente.html
+++ b/pacientes/templates/pacientes/detalle_paciente.html
@@ -12,7 +12,7 @@
     <div class="row">
         <div class="col-md-4">
             <strong>RUT:</strong> {{ paciente.rut }}<br>
-            <strong>Edad:</strong> {{ paciente.edad }}
+            <strong>Edad:</strong> {{ paciente.edad_con_sufijo }}
         </div>
         <div class="col-md-4">
             <strong>Ficha:</strong> {{ paciente.ficha }}<br>

--- a/pacientes/templates/pacientes/epicrisis_template.html
+++ b/pacientes/templates/pacientes/epicrisis_template.html
@@ -81,7 +81,7 @@
                 <!-- Columna 2 -->
                 <td style="width: 33%; vertical-align: top;">
                     <p><strong>FICHA:</strong> {{ ficha }}</p>
-                    <p><strong>EDAD:</strong> {{ paciente.edad }}</p>
+                    <p><strong>EDAD:</strong> {{ paciente.edad_con_sufijo }}</p>
                 </td>
 
                 <!-- Columna 3 -->

--- a/pacientes/templates/pacientes/receta_pdf.html
+++ b/pacientes/templates/pacientes/receta_pdf.html
@@ -14,7 +14,7 @@
     <h1>Receta Médica</h1>
 
     <p><strong>Nombre:</strong> {{ paciente.nombre }}</p>
-    <p><strong>Edad:</strong> {{ edad }}</p>
+    <p><strong>Edad:</strong> {{ paciente.edad_con_sufijo }}</p>
     <p><strong>RUT:</strong> {{ paciente.rut }}</p>
     <p><strong>Ficha:</strong> {{ paciente.ficha }}</p>
     <p><strong>Diagnóstico de ingreso:</strong> {{ paciente.diagnostico }}</p>

--- a/pacientes/views.py
+++ b/pacientes/views.py
@@ -462,7 +462,6 @@ def crear_receta(request, paciente_id):
 
             context = {
                 "paciente": paciente,
-                "edad": paciente.edad(),
                 "dias_tratamiento": dias,
                 "medicamentos": medicamentos,
             }


### PR DESCRIPTION
## Summary
- show age with `años` or `meses` when rendering patient data
- drop unused context entry in prescription view

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687eca5ba47c832cb07edffc9ced3f0f