### PR TITLE
Enable editing and deleting text templates

### DIFF
--- a/pacientes/forms.py
+++ b/pacientes/forms.py
@@ -12,6 +12,7 @@ from .models import (
     Frecuencia,
     Antecedente,
     Indicacion,
+    PlantillaTexto,
 )
 
 from django import forms
@@ -341,5 +342,15 @@ class SolicitudForm(forms.ModelForm):
         widgets = {
             'tipo': forms.Select(attrs={'class': 'form-select'}),
             'detalle': forms.Textarea(attrs={'rows': 3, 'class': 'form-control'}),
+        }
+
+
+class PlantillaTextoForm(forms.ModelForm):
+    class Meta:
+        model = PlantillaTexto
+        fields = ['titulo', 'contenido']
+        widgets = {
+            'titulo': forms.TextInput(attrs={'class': 'form-control'}),
+            'contenido': forms.Textarea(attrs={'rows': 3, 'class': 'form-control'}),
         }
 

--- a/pacientes/templates/pacientes/editar_plantilla.html
+++ b/pacientes/templates/pacientes/editar_plantilla.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h2>Editar Plantilla</h2>
+<form method="post">
+    {% csrf_token %}
+    <div class="mb-2">
+        {{ form.titulo.label_tag }}
+        {{ form.titulo }}
+    </div>
+    <div class="mb-3">
+        {{ form.contenido.label_tag }}
+        {{ form.contenido }}
+    </div>
+    <button type="submit" class="btn btn-primary">Guardar cambios</button>
+    <a href="{% url 'perfil_usuario' %}" class="btn btn-secondary">Cancelar</a>
+</form>
+{% endblock %}

--- a/pacientes/templates/pacientes/perfil_usuario.html
+++ b/pacientes/templates/pacientes/perfil_usuario.html
@@ -18,5 +18,34 @@
         <i class="bi bi-card-text fs-5"></i> Indicaciones
     </button>
 </p>
+
+<table class="table">
+    <thead>
+        <tr>
+            <th>Título</th>
+            <th>Tipo</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for p in plantillas %}
+        <tr>
+            <td>{{ p.titulo|default:"(sin título)" }}</td>
+            <td>{{ p.get_tipo_display }}</td>
+            <td>
+                <a href="{% url 'editar_plantilla' p.id %}" class="btn btn-sm btn-outline-secondary">Editar</a>
+                <form method="post" action="{% url 'eliminar_plantilla' p.id %}" class="d-inline">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-sm btn-danger">Eliminar</button>
+                </form>
+            </td>
+        </tr>
+        {% empty %}
+        <tr>
+            <td colspan="3" class="text-muted">No hay plantillas guardadas.</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
 {% endblock %}
 

--- a/pacientes/urls.py
+++ b/pacientes/urls.py
@@ -36,6 +36,8 @@ urlpatterns = [
     path('api/buscar-paciente/', views.buscar_paciente_api, name='buscar_paciente_api'),
     path('api/plantillas/', views.obtener_plantillas, name='obtener_plantillas'),
     path('api/plantillas/guardar/', views.guardar_plantilla, name='guardar_plantilla'),
+    path('plantillas/<int:plantilla_id>/editar/', views.editar_plantilla, name='editar_plantilla'),
+    path('plantillas/<int:plantilla_id>/eliminar/', views.eliminar_plantilla, name='eliminar_plantilla'),
     path('api/pacientes/<int:paciente_id>/ultima-indicacion/', views.ultima_indicacion, name='ultima_indicacion'),
     path('perfil/', views.perfil_usuario, name='perfil_usuario'),
 ]

--- a/pacientes/views.py
+++ b/pacientes/views.py
@@ -32,6 +32,7 @@ from .forms import (
     SignoVitalForm,
     EvaluacionEnfermeriaForm,
     SolicitudForm,
+    PlantillaTextoForm,
 )
 from .models import (
     Cama,
@@ -697,8 +698,10 @@ def dar_de_alta_paciente(request, paciente_id):
 @login_required
 def perfil_usuario(request):
     perfil = request.user.perfilusuario
+    plantillas = PlantillaTexto.objects.filter(usuario=request.user)
     return render(request, 'pacientes/perfil_usuario.html', {
         'perfil': perfil,
+        'plantillas': plantillas,
     })
 
 
@@ -840,3 +843,26 @@ def guardar_plantilla(request):
         PlantillaTexto.objects.create(usuario=request.user, tipo=tipo, contenido=contenido, titulo=titulo)
         return JsonResponse({'success': True})
     return JsonResponse({'success': False}, status=400)
+
+
+@login_required
+def editar_plantilla(request, plantilla_id):
+    plantilla = get_object_or_404(PlantillaTexto, id=plantilla_id, usuario=request.user)
+    if request.method == 'POST':
+        form = PlantillaTextoForm(request.POST, instance=plantilla)
+        if form.is_valid():
+            form.save()
+            messages.success(request, 'Plantilla modificada correctamente.')
+            return redirect('perfil_usuario')
+    else:
+        form = PlantillaTextoForm(instance=plantilla)
+    return render(request, 'pacientes/editar_plantilla.html', {'form': form})
+
+
+@login_required
+def eliminar_plantilla(request, plantilla_id):
+    plantilla = get_object_or_404(PlantillaTexto, id=plantilla_id, usuario=request.user)
+    if request.method == 'POST':
+        plantilla.delete()
+        messages.success(request, 'Plantilla eliminada correctamente.')
+    return redirect('perfil_usuario')


### PR DESCRIPTION
## Summary
- add `PlantillaTextoForm` to handle template editing
- list user templates in *Mi Perfil* with edit and delete actions
- implement `editar_plantilla` and `eliminar_plantilla` views
- expose new routes for template management
- create template for editing text templates

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687ef2e23bd0832cb6c2f7a06edd8106