### PR TITLE
Add StarCraft II build order helper for GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Build Orders Protoss</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Administrador de Build Orders Protoss</h1>
+  <div class="controls">
+    <label for="matchup">Matchup:</label>
+    <select id="matchup">
+      <option value="">Seleccione</option>
+      <option value="PvP">PvP</option>
+      <option value="PvZ">PvZ</option>
+      <option value="PvT">PvT</option>
+    </select>
+
+    <label for="strategy">Estrategia del oponente:</label>
+    <select id="strategy" disabled>
+      <option value="">Seleccione un matchup primero</option>
+    </select>
+  </div>
+
+  <div id="result"></div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,115 @@
+const data = {
+  PvP: {
+    "4 Gate": {
+      counter: "Defiende con 3 Gate Robo y usa Inmortales.",
+      build: [
+        "14 Pylon",
+        "16 Gateway",
+        "17 Assimilator",
+        "19 Cybernetics Core",
+        "21 Gateway x2",
+        "24 Robotics Facility",
+        "Saca Inmortales y mantén la pared"
+      ]
+    },
+    "Cannon Rush": {
+      counter: "Cancela el Nexus y destruye los cañones con Adeptos/Stalkers.",
+      build: [
+        "14 Pylon",
+        "16 Gateway",
+        "18 Assimilator",
+        "20 Cybernetics Core",
+        "20 Gateway",
+        "Crono a Adeptos y destruye los cañones"
+      ]
+    }
+  },
+  PvZ: {
+    "Zergling Rush": {
+      counter: "Cierra la rampa con Zealots y usa escudos defensivos.",
+      build: [
+        "14 Pylon",
+        "16 Gateway",
+        "17 Assimilator",
+        "20 Cybernetics Core",
+        "22 Nexus",
+        "Añade Forge para cañones defensivos"
+      ]
+    },
+    "Roach Push": {
+      counter: "Tres Gate Robo con Inmortales y Sentries para force fields.",
+      build: [
+        "14 Pylon",
+        "16 Gateway",
+        "17 Assimilator",
+        "20 Cybernetics Core",
+        "22 Nexus",
+        "23 Gateway x2",
+        "27 Robotics Facility",
+        "Saca Inmortales y Sentries"
+      ]
+    }
+  },
+  PvT: {
+    "Reaper Expand": {
+      counter: "Defiende con Stalkers rápidos y contraataca con Blink.",
+      build: [
+        "14 Pylon",
+        "16 Gateway",
+        "17 Assimilator",
+        "19 Cybernetics Core",
+        "23 Nexus",
+        "25 Twilight Council",
+        "30 Blink + Gateways adicionales"
+      ]
+    },
+    "1-1-1": {
+      counter: "Temporiza con Blink Stalkers o Colosos rápidos.",
+      build: [
+        "14 Pylon",
+        "16 Gateway",
+        "17 Assimilator",
+        "19 Cybernetics Core",
+        "23 Nexus",
+        "25 Robotics Facility",
+        "30 Robotics Bay",
+        "Saca Colosos y Gateways adicionales"
+      ]
+    }
+  }
+};
+
+const matchupSelect = document.getElementById('matchup');
+const strategySelect = document.getElementById('strategy');
+const resultDiv = document.getElementById('result');
+
+matchupSelect.addEventListener('change', () => {
+  const matchup = matchupSelect.value;
+  strategySelect.innerHTML = '';
+  resultDiv.innerHTML = '';
+  if (!matchup) {
+    strategySelect.disabled = true;
+    strategySelect.innerHTML = '<option value="">Seleccione un matchup primero</option>';
+    return;
+  }
+  strategySelect.disabled = false;
+  strategySelect.innerHTML = '<option value="">Seleccione</option>';
+  Object.keys(data[matchup]).forEach(strat => {
+    const opt = document.createElement('option');
+    opt.value = strat;
+    opt.textContent = strat;
+    strategySelect.appendChild(opt);
+  });
+});
+
+strategySelect.addEventListener('change', () => {
+  const matchup = matchupSelect.value;
+  const strat = strategySelect.value;
+  if (!strat) {
+    resultDiv.innerHTML = '';
+    return;
+  }
+  const info = data[matchup][strat];
+  const list = info.build.map(step => `<li>${step}</li>`).join('');
+  resultDiv.innerHTML = `<h2>Counter: ${info.counter}</h2><ol>${list}</ol>`;
+});

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,28 @@
+body {
+  font-family: Arial, sans-serif;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+h1 {
+  text-align: center;
+}
+
+.controls {
+  margin-bottom: 1rem;
+}
+
+label {
+  margin-right: 0.5rem;
+}
+
+select {
+  margin-right: 1rem;
+}
+
+#result {
+  background: #f9f9f9;
+  border: 1px solid #ccc;
+  padding: 1rem;
+}


### PR DESCRIPTION
## Summary
- Create GitHub Pages site to manage Protoss build orders against PvP, PvZ and PvT
- Provide interactive selectors and algorithm to display counters and step-by-step orders

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689e6c25de94832c815cdbf0f204fe57